### PR TITLE
Update to Spoofax 2.4

### DIFF
--- a/lambdaJS.interpreter/.classpath
+++ b/lambdaJS.interpreter/.classpath
@@ -35,5 +35,10 @@
 			<attribute name="m2e-apt" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/lambdaJS.interpreter/.factorypath
+++ b/lambdaJS.interpreter/.factorypath
@@ -1,19 +1,18 @@
 <factorypath>
-    <factorypathentry kind="VARJAR" id="M2_REPO/org/metaborg/org.metaborg.meta.lang.dynsem.interpreter/2.3.0-SNAPSHOT/org.metaborg.meta.lang.dynsem.interpreter-2.3.0-SNAPSHOT.jar" enabled="true" runInBatchMode="false"/>
     <factorypathentry kind="VARJAR" id="M2_REPO/com/github/krukow/clj-ds/0.0.4/clj-ds-0.0.4.jar" enabled="true" runInBatchMode="false"/>
-    <factorypathentry kind="VARJAR" id="M2_REPO/org/metaborg/org.strategoxt.strj/2.3.0-SNAPSHOT/org.strategoxt.strj-2.3.0-SNAPSHOT.jar" enabled="true" runInBatchMode="false"/>
-    <factorypathentry kind="VARJAR" id="M2_REPO/org/metaborg/org.spoofax.interpreter.core/2.3.0-SNAPSHOT/org.spoofax.interpreter.core-2.3.0-SNAPSHOT.jar" enabled="true" runInBatchMode="false"/>
-    <factorypathentry kind="VARJAR" id="M2_REPO/org/metaborg/org.spoofax.interpreter.library.xml/2.3.0-SNAPSHOT/org.spoofax.interpreter.library.xml-2.3.0-SNAPSHOT.jar" enabled="true" runInBatchMode="false"/>
-    <factorypathentry kind="VARJAR" id="M2_REPO/org/metaborg/org.spoofax.interpreter.library.java/2.3.0-SNAPSHOT/org.spoofax.interpreter.library.java-2.3.0-SNAPSHOT.jar" enabled="true" runInBatchMode="false"/>
-    <factorypathentry kind="VARJAR" id="M2_REPO/org/metaborg/org.spoofax.interpreter.library.index/2.3.0-SNAPSHOT/org.spoofax.interpreter.library.index-2.3.0-SNAPSHOT.jar" enabled="true" runInBatchMode="false"/>
-    <factorypathentry kind="VARJAR" id="M2_REPO/org/metaborg/org.spoofax.jsglr/2.3.0-SNAPSHOT/org.spoofax.jsglr-2.3.0-SNAPSHOT.jar" enabled="true" runInBatchMode="false"/>
-    <factorypathentry kind="VARJAR" id="M2_REPO/org/metaborg/org.spoofax.interpreter.library.jsglr/2.3.0-SNAPSHOT/org.spoofax.interpreter.library.jsglr-2.3.0-SNAPSHOT.jar" enabled="true" runInBatchMode="false"/>
-    <factorypathentry kind="VARJAR" id="M2_REPO/org/metaborg/strategoxt-min-jar/2.3.0-SNAPSHOT/strategoxt-min-jar-2.3.0-SNAPSHOT.jar" enabled="true" runInBatchMode="false"/>
-    <factorypathentry kind="VARJAR" id="M2_REPO/org/metaborg/org.metaborg.core/2.3.0-SNAPSHOT/org.metaborg.core-2.3.0-SNAPSHOT.jar" enabled="true" runInBatchMode="false"/>
-    <factorypathentry kind="VARJAR" id="M2_REPO/org/metaborg/org.metaborg.util/2.3.0-SNAPSHOT/org.metaborg.util-2.3.0-SNAPSHOT.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/org/metaborg/org.strategoxt.strj/2.4.0-SNAPSHOT/org.strategoxt.strj-2.4.0-SNAPSHOT.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/org/metaborg/org.spoofax.interpreter.core/2.4.0-SNAPSHOT/org.spoofax.interpreter.core-2.4.0-SNAPSHOT.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/org/metaborg/org.spoofax.interpreter.library.xml/2.4.0-SNAPSHOT/org.spoofax.interpreter.library.xml-2.4.0-SNAPSHOT.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/org/metaborg/org.spoofax.interpreter.library.java/2.4.0-SNAPSHOT/org.spoofax.interpreter.library.java-2.4.0-SNAPSHOT.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/org/metaborg/org.spoofax.interpreter.library.index/2.4.0-SNAPSHOT/org.spoofax.interpreter.library.index-2.4.0-SNAPSHOT.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/org/metaborg/org.spoofax.jsglr/2.4.0-SNAPSHOT/org.spoofax.jsglr-2.4.0-SNAPSHOT.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/org/metaborg/sdf2table/2.4.0-SNAPSHOT/sdf2table-2.4.0-SNAPSHOT.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/org/metaborg/org.spoofax.interpreter.library.jsglr/2.4.0-SNAPSHOT/org.spoofax.interpreter.library.jsglr-2.4.0-SNAPSHOT.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/org/metaborg/strategoxt-min-jar/2.4.0-SNAPSHOT/strategoxt-min-jar-2.4.0-SNAPSHOT.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/org/metaborg/org.metaborg.core/2.4.0-SNAPSHOT/org.metaborg.core-2.4.0-SNAPSHOT.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/org/metaborg/org.metaborg.util/2.4.0-SNAPSHOT/org.metaborg.util-2.4.0-SNAPSHOT.jar" enabled="true" runInBatchMode="false"/>
     <factorypathentry kind="VARJAR" id="M2_REPO/junit/junit/4.12/junit-4.12.jar" enabled="true" runInBatchMode="false"/>
     <factorypathentry kind="VARJAR" id="M2_REPO/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar" enabled="true" runInBatchMode="false"/>
-    <factorypathentry kind="VARJAR" id="M2_REPO/org/slf4j/slf4j-api/1.7.10/slf4j-api-1.7.10.jar" enabled="true" runInBatchMode="false"/>
     <factorypathentry kind="VARJAR" id="M2_REPO/com/google/inject/guice/4.0/guice-4.0.jar" enabled="true" runInBatchMode="false"/>
     <factorypathentry kind="VARJAR" id="M2_REPO/javax/inject/javax.inject/1/javax.inject-1.jar" enabled="true" runInBatchMode="false"/>
     <factorypathentry kind="VARJAR" id="M2_REPO/aopalliance/aopalliance/1.0/aopalliance-1.0.jar" enabled="true" runInBatchMode="false"/>
@@ -29,21 +28,27 @@
     <factorypathentry kind="VARJAR" id="M2_REPO/org/yaml/snakeyaml/1.15/snakeyaml-1.15.jar" enabled="true" runInBatchMode="false"/>
     <factorypathentry kind="VARJAR" id="M2_REPO/com/google/guava/guava/17.0/guava-17.0.jar" enabled="true" runInBatchMode="false"/>
     <factorypathentry kind="VARJAR" id="M2_REPO/com/netflix/rxjava/rxjava-core/0.20.7/rxjava-core-0.20.7.jar" enabled="true" runInBatchMode="false"/>
-    <factorypathentry kind="VARJAR" id="M2_REPO/it/unimi/dsi/fastutil/7.0.12/fastutil-7.0.12.jar" enabled="true" runInBatchMode="false"/>
-    <factorypathentry kind="VARJAR" id="M2_REPO/org/metaborg/org.metaborg.spoofax.core/2.3.0-SNAPSHOT/org.metaborg.spoofax.core-2.3.0-SNAPSHOT.jar" enabled="true" runInBatchMode="false"/>
-    <factorypathentry kind="VARJAR" id="M2_REPO/org/metaborg/org.metaborg.meta.nabl2.java/2.3.0-SNAPSHOT/org.metaborg.meta.nabl2.java-2.3.0-SNAPSHOT.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/it/unimi/dsi/fastutil/8.1.0/fastutil-8.1.0.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/org/metaborg/org.metaborg.spoofax.core/2.4.0-SNAPSHOT/org.metaborg.spoofax.core-2.4.0-SNAPSHOT.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/org/metaborg/org.metaborg.meta.nabl2.java/2.4.0-SNAPSHOT/org.metaborg.meta.nabl2.java-2.4.0-SNAPSHOT.jar" enabled="true" runInBatchMode="false"/>
     <factorypathentry kind="VARJAR" id="M2_REPO/org/pcollections/pcollections/2.1.2/pcollections-2.1.2.jar" enabled="true" runInBatchMode="false"/>
-    <factorypathentry kind="VARJAR" id="M2_REPO/org/metaborg/org.metaborg.runtime.task/2.3.0-SNAPSHOT/org.metaborg.runtime.task-2.3.0-SNAPSHOT.jar" enabled="true" runInBatchMode="false"/>
-    <factorypathentry kind="VARJAR" id="M2_REPO/org/metaborg/org.spoofax.terms.typesmart/2.3.0-SNAPSHOT/org.spoofax.terms.typesmart-2.3.0-SNAPSHOT.jar" enabled="true" runInBatchMode="false"/>
-    <factorypathentry kind="VARJAR" id="M2_REPO/org/metaborg/dynsem.lib.stratego.javastrat/2.3.0-SNAPSHOT/dynsem.lib.stratego.javastrat-2.3.0-SNAPSHOT.jar" enabled="true" runInBatchMode="false"/>
-    <factorypathentry kind="VARJAR" id="M2_REPO/org/metaborg/dynsem.lib.stratego.jar/2.3.0-SNAPSHOT/dynsem.lib.stratego.jar-2.3.0-SNAPSHOT.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/org/metaborg/org.spoofax.jsglr2/2.4.0-SNAPSHOT/org.spoofax.jsglr2-2.4.0-SNAPSHOT.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/org/metaborg/org.metaborg.spoofax.nativebundle/2.4.0-SNAPSHOT/org.metaborg.spoofax.nativebundle-2.4.0-SNAPSHOT.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/org/metaborg/org.metaborg.runtime.task/2.4.0-SNAPSHOT/org.metaborg.runtime.task-2.4.0-SNAPSHOT.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/org/metaborg/org.spoofax.terms.typesmart/2.4.0-SNAPSHOT/org.spoofax.terms.typesmart-2.4.0-SNAPSHOT.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/org/metaborg/dynsem.lib.stratego.javastrat/2.4.0-SNAPSHOT/dynsem.lib.stratego.javastrat-2.4.0-SNAPSHOT.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/org/metaborg/dynsem.lib.stratego.jar/2.4.0-SNAPSHOT/dynsem.lib.stratego.jar-2.4.0-SNAPSHOT.jar" enabled="true" runInBatchMode="false"/>
     <factorypathentry kind="VARJAR" id="M2_REPO/org/apache/commons/commons-lang3/3.3.2/commons-lang3-3.3.2.jar" enabled="true" runInBatchMode="false"/>
     <factorypathentry kind="VARJAR" id="M2_REPO/commons-io/commons-io/2.5/commons-io-2.5.jar" enabled="true" runInBatchMode="false"/>
     <factorypathentry kind="VARJAR" id="M2_REPO/org/mockito/mockito-core/2.0.76-beta/mockito-core-2.0.76-beta.jar" enabled="true" runInBatchMode="false"/>
     <factorypathentry kind="VARJAR" id="M2_REPO/net/bytebuddy/byte-buddy/1.4.3/byte-buddy-1.4.3.jar" enabled="true" runInBatchMode="false"/>
     <factorypathentry kind="VARJAR" id="M2_REPO/org/objenesis/objenesis/2.4/objenesis-2.4.jar" enabled="true" runInBatchMode="false"/>
-    <factorypathentry kind="VARJAR" id="M2_REPO/com/oracle/truffle/truffle-api/0.15/truffle-api-0.15.jar" enabled="true" runInBatchMode="false"/>
-    <factorypathentry kind="VARJAR" id="M2_REPO/com/oracle/truffle/truffle-dsl-processor/0.15/truffle-dsl-processor-0.15.jar" enabled="true" runInBatchMode="false"/>
-    <factorypathentry kind="VARJAR" id="M2_REPO/org/metaborg/org.spoofax.terms/2.3.0-SNAPSHOT/org.spoofax.terms-2.3.0-SNAPSHOT.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/com/oracle/truffle/truffle-api/0.26/truffle-api-0.26.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/com/oracle/truffle/truffle-dsl-processor/0.26/truffle-dsl-processor-0.26.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/org/metaborg/org.spoofax.terms/2.4.0-SNAPSHOT/org.spoofax.terms-2.4.0-SNAPSHOT.jar" enabled="true" runInBatchMode="false"/>
     <factorypathentry kind="VARJAR" id="M2_REPO/com/martiansoftware/nailgun-server/0.9.1/nailgun-server-0.9.1.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/org/slf4j/slf4j-api/1.7.10/slf4j-api-1.7.10.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/org/slf4j/jcl-over-slf4j/1.7.10/jcl-over-slf4j-1.7.10.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/ch/qos/logback/logback-classic/1.1.2/logback-classic-1.1.2.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/ch/qos/logback/logback-core/1.1.2/logback-core-1.1.2.jar" enabled="true" runInBatchMode="false"/>
 </factorypath>

--- a/lambdaJS.interpreter/.gitignore
+++ b/lambdaJS.interpreter/.gitignore
@@ -1,7 +1,14 @@
 
-/target/
+/bin
+/target
+/.project
+/.classpath
+/.settings
+/.factorypath
+file:///Users/vladvergu/tud/slde/software/languages/nonmeta/metaborg-lambdaJS/lambdaJS.interpreter/src/main/resources/signatures-digest.cache
 src/main/resources/specification.aterm
 src/main/resources/parsetable.tbl
+src/main/resources/logback.xml
 src/main/java/org/metaborg/lambdaJS/interpreter/generated
 src/main/java/org/metaborg/lambdaJS/interpreter/generated/terms
 src/main/java/org/metaborg/lambdaJS/interpreter/generated/terms/build
@@ -9,7 +16,9 @@ src/main/java/org/metaborg/lambdaJS/interpreter/generated/terms/match
 src/test/java/org/metaborg/lambdaJS/interpreter/generated/test
 /lambdaJS.launch
 /TestlambdaJS.launch
+/lambdaJS (Core).launch
 /lambdaJS (Daemon).launch
+/lambdaJS-core
 /lambdaJS-server
 /lambdaJS-client
 /lambdaJS

--- a/lambdaJS.interpreter/pom.xml
+++ b/lambdaJS.interpreter/pom.xml
@@ -80,32 +80,51 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
       </snapshots>
     </repository>
   </repositories>
+  <properties>
+    <slf4j.version>1.7.10</slf4j.version>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>org.metaborg</groupId>
       <artifactId>org.metaborg.meta.lang.dynsem.interpreter</artifactId>
-      <version>2.3.0-SNAPSHOT</version>
+      <version>2.4.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.truffle</groupId>
       <artifactId>truffle-api</artifactId>
-      <version>0.15</version>
+      <version>0.26</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>com.oracle.truffle</groupId>
       <artifactId>truffle-dsl-processor</artifactId>
-      <version>0.15</version>
+      <version>0.26</version>
     </dependency>
     <dependency>
       <groupId>org.metaborg</groupId>
       <artifactId>org.spoofax.terms</artifactId>
-      <version>2.3.0-SNAPSHOT</version>
+      <version>2.4.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.martiansoftware</groupId>
       <artifactId>nailgun-server</artifactId>
       <version>0.9.1</version>
+    </dependency>
+    <!-- Logging -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${slf4j.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>jcl-over-slf4j</artifactId>
+      <version>${slf4j.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>1.1.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/lambdaJS/pom.xml
+++ b/lambdaJS/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.metaborg</groupId>
     <artifactId>parent.language</artifactId>
-    <version>2.3.0-SNAPSHOT</version>
+    <version>2.4.0-SNAPSHOT</version>
   </parent>
   
   <repositories>

--- a/lambdaJS/trans/lambdajs.ds
+++ b/lambdaJS/trans/lambdajs.ds
@@ -1,7 +1,7 @@
-module trans/lambdaJS
+module trans/lambdajs
 
 imports
-src-gen/ds-signatures/lambdaJS-sig
+  src-gen/ds-signatures/lambdaJS-sig
 
 signature
 	sorts


### PR DESCRIPTION
Update to Spoofax 2.4.

If *lambdaJS* files you are attempting to evaluate contain spaces in their paths, then you will also need a v. recent DynSem (corresponding to commit > https://github.com/metaborg/dynsem/commit/90bfa92cbb5cce9ab93aa823251f271282309a6d). 